### PR TITLE
fix: NullInjectorError thrown while running tests

### DIFF
--- a/src/app/components/login/login.component.spec.ts
+++ b/src/app/components/login/login.component.spec.ts
@@ -1,31 +1,37 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { FormsModule, NgForm } from '@angular/forms';
-import { Router } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { of, throwError } from 'rxjs';
 
 import { LoginComponent } from './login.component';
 import { AuthService } from '../../auth/services/auth.service';
+import { MainLayoutComponent } from '../layouts/main-layout.component';
+import { provideLocationMocks } from '@angular/common/testing';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
   let authServiceSpy: jasmine.SpyObj<AuthService>;
-  let routerSpy: jasmine.SpyObj<Router>;
+  let router: Router;
 
   beforeEach(async () => {
     authServiceSpy = jasmine.createSpyObj('AuthService', ['login']);
-    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
 
     await TestBed.configureTestingModule({
       imports: [LoginComponent,FormsModule],
       providers: [
-        { provide: AuthService, useValue: authServiceSpy },
-        { provide: Router,      useValue: routerSpy }
+        provideRouter([{ path: 'main', component: MainLayoutComponent }]),
+        provideLocationMocks(),
+        { provide: AuthService, useValue: authServiceSpy }
       ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(LoginComponent);
     component = fixture.componentInstance;
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+
     fixture.detectChanges();
   });
 
@@ -70,7 +76,7 @@ describe('LoginComponent', () => {
       expect(authServiceSpy.login).toHaveBeenCalledOnceWith({
         email: 'u@mail.com', password: 'pass'
       });
-      expect(routerSpy.navigate).toHaveBeenCalledWith(['/main']);
+      expect(router.navigate).toHaveBeenCalledWith(['/main']);
     }));
 
     it('onSubmit should set errorMessage on login error', fakeAsync(() => {

--- a/src/app/components/register/register.component.spec.ts
+++ b/src/app/components/register/register.component.spec.ts
@@ -1,21 +1,26 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { FormsModule, NgForm } from '@angular/forms';
 import { of, throwError } from 'rxjs';
-
+import { provideRouter, Router }                      from '@angular/router';
 import { RegisterComponent } from './register.component';
 import { AuthService } from '../../auth/services/auth.service';
+import { provideLocationMocks } from '@angular/common/testing';
+import { MainLayoutComponent } from '../layouts/main-layout.component';
 
 describe('RegisterComponent', () => {
   let component: RegisterComponent;
   let fixture: ComponentFixture<RegisterComponent>;
   let authServiceSpy: jasmine.SpyObj<AuthService>;
-
+  let router: Router;
+  
   beforeEach(async () => {
     authServiceSpy = jasmine.createSpyObj('AuthService', ['register']);
 
     await TestBed.configureTestingModule({
       imports: [RegisterComponent, FormsModule],
       providers: [
+        provideRouter([{ path: 'main', component: MainLayoutComponent }]),
+        provideLocationMocks(),
         { provide: AuthService, useValue: authServiceSpy }
       ]
     }).compileComponents();
@@ -67,7 +72,7 @@ describe('RegisterComponent', () => {
     component.password = 'Password1';
     component.confirmPassword = 'Password1';
 
-    authServiceSpy.register.and.returnValue(of({}));
+    authServiceSpy.register.and.returnValue(of({ token: 'dummy-token' }));
 
     component.onRegister(fakeForm);
     tick();


### PR DESCRIPTION
Fixed a NullInjectorError when testing navigation by replacing the manual Router spy with provideRouter. The old approach caused issues because the Router wasn’t properly initialized in standalone component tests. Now using provideRouter to register routes and allow navigation to work correctly in tests.