### PR TITLE
feat: board page with full functionalities

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@angular/ssr": "^19.2.11",
         "@tailwindcss/postcss": "^4.1.6",
         "express": "^4.18.2",
+        "ngx-drag-scroll": "^19.0.0-rc.0",
         "postcss": "^8.5.3",
         "rxjs": "~7.8.0",
         "tailwindcss": "^4.1.6",
@@ -1288,6 +1289,8 @@
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
+
+    "ngx-drag-scroll": ["ngx-drag-scroll@19.0.0-rc.0", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/common": ">=5.0.0 <20.0.0", "@angular/core": ">=5.0.0 <20.0.0" } }, "sha512-Aq4dLS436chQnZCpljKzqserEPro6U3bg3NcmJm/T3DHRt1Rnpa6mXCqoP9QM7d5mExPBW5xiyVrpRtMhN9XZw=="],
 
     "node-addon-api": ["node-addon-api@6.1.0", "", {}, "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@angular/ssr": "^19.2.11",
     "@tailwindcss/postcss": "^4.1.6",
     "express": "^4.18.2",
+    "ngx-drag-scroll": "^19.0.0-rc.0",
     "postcss": "^8.5.3",
     "rxjs": "~7.8.0",
     "tailwindcss": "^4.1.6",

--- a/src/app/components/board/board.component.css
+++ b/src/app/components/board/board.component.css
@@ -1,0 +1,3 @@
+:host ::ng-deep .drag-scroll-content {
+    width: initial !important;
+}

--- a/src/app/components/board/board.component.html
+++ b/src/app/components/board/board.component.html
@@ -1,0 +1,58 @@
+<div *ngIf="board" class="flex flex-col space-y-4 h-full" >
+    <div #boardTitleContainer class="flex items-center justify-center bg-darkblue text-lightblue p-4 ">
+
+        <input class="text-center text-xl font-semibold px-2 py-1 bg-darkblue text-lightblue focus:outline-none"
+            #titleInputRef
+            [(ngModel)]="boardTitle"
+            type="text"
+            [placeholder]="boardTitle"
+            (keydown.enter)="saveTitleIfChanged()"
+            (focus)="onFocusTitle()"
+            (blur)="onBlurTitle()"
+            />
+
+        <button *ngIf="showDeleteButton"
+            class="absolute right-10 text-red-100 hover:text-red-700 text-xl focus:outline-none z-10"
+            (click)="deleteBoard()"
+            aria-label="Delete board">
+            ✖
+        </button>
+      </div>
+
+
+    <drag-scroll
+    class="flex-1 py-6 w-full overflow-x-auto overflow-y-hidden cursor-grab
+    [&::-webkit-scrollbar]:h-2 
+    [&::-webkit-scrollbar-track]:bg-darkgrey 
+    [&::-webkit-scrollbar-thumb]:bg-darkblue"
+    [scrollbar-hidden]="true"
+  >
+    <ng-container *ngIf="loading">
+    <p>Loading tasks...</p>
+    </ng-container>
+
+        <div class="flex flex-row space-x-4 select-none drag-scroll-item">
+            <ng-container *ngIf="!loading && tasks.length > 0">
+                <app-task *ngFor="let task of tasks" [task]="task"></app-task>
+            </ng-container>
+        </div>
+
+        <ng-container *ngIf="!loading && tasks.length === 0">
+        <p class="text-gray-500">This board has no tasks.</p>
+        </ng-container>
+    </drag-scroll>
+
+    <app-confirm-dialog
+        *ngIf="showConfirm"
+        [message]="confirmMessage"
+        (confirm)="handleConfirm()"
+        (cancel)="handleCancel()"
+    ></app-confirm-dialog>
+
+    <app-toast
+        *ngIf="toastMessage"
+        [message]="toastMessage"
+        [type]="toastType"
+    ></app-toast>
+
+</div>

--- a/src/app/components/board/board.component.html
+++ b/src/app/components/board/board.component.html
@@ -28,16 +28,34 @@
     [&::-webkit-scrollbar-track]:bg-darkgrey 
     [&::-webkit-scrollbar-thumb]:bg-darkblue"
     [scrollbar-hidden]="true"
-  >
+    >
+
+    
+
     <ng-container *ngIf="loading">
     <p>Loading tasks...</p>
     </ng-container>
 
-        <div class="flex flex-row space-x-4 select-none drag-scroll-item">
-            <ng-container *ngIf="!loading && tasks.length > 0">
-                <app-task *ngFor="let task of tasks" [task]="task"></app-task>
-            </ng-container>
+    <div class="flex flex-row space-x-4 drag-scroll-item">
+        
+        <div #newTaskInputContainer class="border border-dashed border-lightblue min-w-60 h-20 p-3 my-2 bg-lightgrey content-center select-none">
+            <input
+            #newTaskInput
+            [(ngModel)]="newTaskName"
+            (keydown.enter)="handleTaskCreationAttempt()"
+            (focus)="onNewTaskInputFocus()"
+            (blur)="onNewTaskInputBlur()"
+            type="text"
+            [placeholder]="newTaskPlaceholder"
+            class="w-full px-4 py-2 text-lightblue text-lg font-bold text-center focus:outline-none"
+            />
         </div>
+
+        <ng-container *ngIf="!loading && tasks.length > 0">
+            <app-task *ngFor="let task of tasks" [task]="task" 
+            (taskDeleted)="onTaskDeleted($event)"></app-task>
+        </ng-container>
+    </div>
     </drag-scroll>
 
     <app-confirm-dialog

--- a/src/app/components/board/board.component.html
+++ b/src/app/components/board/board.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="board" class="flex flex-col space-y-4 h-full" >
-    <div #boardTitleContainer class="flex items-center justify-center bg-darkblue text-lightblue p-4 ">
+    <div #boardTitleContainer class="flex items-center justify-center bg-lightgrey p-4 border border-lightblue">
 
-        <input class="text-center text-xl font-semibold px-2 py-1 bg-darkblue text-lightblue focus:outline-none"
+        <input class="text-center mx-7 w-full h-full text-3xl font-semibold px-2 py-1 text-marfilwhite focus:outline-none focus:text-lightblue truncate" 
             #titleInputRef
             [(ngModel)]="boardTitle"
             type="text"
@@ -12,10 +12,12 @@
             />
 
         <button *ngIf="showDeleteButton"
-            class="absolute right-10 text-red-100 hover:text-red-700 text-xl focus:outline-none z-10"
+            class="absolute right-10 text-xl focus:outline-none"
             (click)="deleteBoard()"
             aria-label="Delete board">
-            ✖
+            <svg viewBox="0 0 32 32" fill="#fb2c36" version="1.1" class="w-7 h-7" xmlns="http://www.w3.org/2000/svg">
+                <path d="M30 7.249h-5.598l-3.777-5.665c-0.137-0.202-0.366-0.334-0.625-0.334h-8c-0 0-0.001 0-0.001 0-0.259 0-0.487 0.131-0.621 0.331l-0.002 0.003-3.777 5.665h-5.599c-0.414 0-0.75 0.336-0.75 0.75s0.336 0.75 0.75 0.75v0h3.315l1.938 21.319c0.036 0.384 0.356 0.682 0.747 0.682 0 0 0 0 0.001 0h16c0 0 0.001 0 0.001 0 0.39 0 0.71-0.298 0.745-0.679l0-0.003 1.938-21.319h3.316c0.414 0 0.75-0.336 0.75-0.75s-0.336-0.75-0.75-0.75v0zM12.401 2.75h7.196l2.999 4.499h-13.195zM23.314 29.25h-14.63l-1.863-20.5 18.358-0.001zM11 11.25c-0.414 0-0.75 0.336-0.75 0.75v0 14c0 0.414 0.336 0.75 0.75 0.75s0.75-0.336 0.75-0.75v0-14c-0-0.414-0.336-0.75-0.75-0.75v0zM16 11.25c-0.414 0-0.75 0.336-0.75 0.75v0 14c0 0.414 0.336 0.75 0.75 0.75s0.75-0.336 0.75-0.75v0-14c-0-0.414-0.336-0.75-0.75-0.75v0zM21 11.25c-0.414 0-0.75 0.336-0.75 0.75v0 14c0 0.414 0.336 0.75 0.75 0.75s0.75-0.336 0.75-0.75v0-14c-0-0.414-0.336-0.75-0.75-0.75v0z"></path>
+                </svg>
         </button>
       </div>
 
@@ -36,10 +38,6 @@
                 <app-task *ngFor="let task of tasks" [task]="task"></app-task>
             </ng-container>
         </div>
-
-        <ng-container *ngIf="!loading && tasks.length === 0">
-        <p class="text-gray-500">This board has no tasks.</p>
-        </ng-container>
     </drag-scroll>
 
     <app-confirm-dialog

--- a/src/app/components/board/board.component.spec.ts
+++ b/src/app/components/board/board.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BoardComponent } from './board.component';
+
+describe('BoardComponent', () => {
+  let component: BoardComponent;
+  let fixture: ComponentFixture<BoardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BoardComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(BoardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/board/board.component.spec.ts
+++ b/src/app/components/board/board.component.spec.ts
@@ -1,23 +1,170 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { BoardComponent } from './board.component';
+import { TaskService } from '../../services/task.service';
+import { BoardService } from '../../services/board.service';
+import { of, throwError } from 'rxjs';
+import { Task } from '../../models/task.model';
+import { Board } from '../../models/board.model';
+import { ElementRef } from '@angular/core';
+import { DragScrollComponent } from 'ngx-drag-scroll';
+import { FormsModule } from '@angular/forms';
+import { ToastComponent } from '../toast/toast.component';
+import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.component';
 
 describe('BoardComponent', () => {
   let component: BoardComponent;
   let fixture: ComponentFixture<BoardComponent>;
+  let taskServiceSpy: jasmine.SpyObj<TaskService>;
+  let boardServiceSpy: jasmine.SpyObj<BoardService>;
+
+  const mockTasks: Task[] = [
+    { id: 1, title: 'Task 1', completed: false, items: [] },
+    { id: 2, title: 'Task 2', completed: true, items: [] }
+  ];
 
   beforeEach(async () => {
+    taskServiceSpy = jasmine.createSpyObj('TaskService', ['getTasksByBoard', 'createTask']);
+    boardServiceSpy = jasmine.createSpyObj('BoardService', ['updateBoard', 'deleteBoard', 'notifyBoardDeleted']);
+
     await TestBed.configureTestingModule({
-      imports: [BoardComponent]
-    })
-    .compileComponents();
+      imports: [
+        BoardComponent,
+        FormsModule,
+        DragScrollComponent,
+        ToastComponent,
+        ConfirmDialogComponent
+      ],
+      providers: [
+        { provide: TaskService, useValue: taskServiceSpy },
+        { provide: BoardService, useValue: boardServiceSpy }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(BoardComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.titleInputRef = new ElementRef(document.createElement('input'));
+    component.newTaskInputContainerRef = new ElementRef(document.createElement('div'));
+    component.board = { id: 42, title: 'My Board' };
   });
 
-  it('should create', () => {
+  it('should create and set initial title', () => {
     expect(component).toBeTruthy();
+    expect(component.boardTitle).toBe('');
   });
+
+  it('ngOnInit + fetch tasks success', () => {
+    taskServiceSpy.getTasksByBoard.and.returnValue(of(mockTasks));
+    component.ngOnInit();
+    expect(taskServiceSpy.getTasksByBoard).toHaveBeenCalledWith(42);
+    expect(component.tasks).toEqual(mockTasks);
+    expect(component.loading).toBeFalse();
+  });
+
+  it('ngOnInit + fetch tasks error', () => {
+    taskServiceSpy.getTasksByBoard.and.returnValue(throwError(() => new Error()));
+    component.ngOnInit();
+    expect(component.toastMessage).toBe('Failed to load board data.');
+    expect(component.toastType).toBe('error');
+  });
+
+  it('ngOnChanges should re-fetch tasks', () => {
+    taskServiceSpy.getTasksByBoard.and.returnValue(of(mockTasks));
+    component.ngOnChanges();
+    expect(taskServiceSpy.getTasksByBoard).toHaveBeenCalled();
+  });
+
+  it('saveTitleIfChanged: success path', () => {
+    component.board.title = 'Old';
+    component.originalTitle = 'Old';
+    component.boardTitle = 'New';
+    boardServiceSpy.updateBoard.and.returnValue(of({ id: 42, title: 'New' } as Board));
+    spyOn(component.titleInputRef.nativeElement, 'blur');
+    component.saveTitleIfChanged();
+    expect(boardServiceSpy.updateBoard).toHaveBeenCalledWith(42, jasmine.objectContaining({ title: 'New' }));
+    expect(component.originalTitle).toBe('New');
+    expect(component.titleInputRef.nativeElement.blur).toHaveBeenCalled();
+  });
+
+  it('saveTitleIfChanged: no-change or empty resets title', () => {
+    component.originalTitle = 'X';
+    component.boardTitle = '   ';
+    component.saveTitleIfChanged();
+    expect(component.boardTitle).toBe('X');
+  });
+
+  it('saveTitleIfChanged: error path', () => {
+    component.originalTitle = 'X';
+    component.boardTitle = 'Y';
+    boardServiceSpy.updateBoard.and.returnValue(throwError(() => new Error()));
+    component.saveTitleIfChanged();
+    expect(component.toastMessage).toBe('Failed to update board.');
+    expect(component.boardTitle).toBe('X');
+  });
+
+  it('cancelEditing should reset title', () => {
+    component.originalTitle = 'Orig';
+    component.boardTitle = 'Changed';
+    component.cancelEditing();
+    expect(component.boardTitle).toBe('Orig');
+  });
+
+  it('onFocusTitle and onBlurTitle toggles delete button', fakeAsync(() => {
+    component.onFocusTitle();
+    expect(component.showDeleteButton).toBeTrue();
+    component.onBlurTitle();
+    tick(200);
+    expect(component.showDeleteButton).toBeFalse();
+  }));
+
+  it('deleteBoard success path via confirm', () => {
+    component.board = { id: 5, title: 'B' };
+    boardServiceSpy.deleteBoard.and.returnValue(of(undefined));
+    spyOn(component, 'openConfirm').and.callThrough();
+    component.deleteBoard();
+    expect(component.openConfirm).toHaveBeenCalled();
+    component.confirmAction();
+    expect(boardServiceSpy.notifyBoardDeleted).toHaveBeenCalled();
+  });
+
+  it('deleteBoard error path', () => {
+    boardServiceSpy.deleteBoard.and.returnValue(throwError(() => new Error()));
+    component.deleteBoard();
+    component.confirmAction();
+    expect(component.toastMessage).toBe('Failed to delete board.');
+  });
+
+  it('onNewTaskInputFocus/Blur placeholder behavior', () => {
+    component.onNewTaskInputFocus();
+    expect(component.newTaskPlaceholder).toBe('Enter task name');
+    component.newTaskName = 'foo';
+    component.onNewTaskInputBlur();
+    expect(component.newTaskName).toBe('');
+    expect(component.newTaskPlaceholder).toBe('New Task...');
+  });
+
+  it('handleTaskCreationAttempt: success & empty', () => {
+    component.board = { id: 7, title: 'T' };
+    component.newTaskName = 'A';
+    taskServiceSpy.createTask.and.returnValue(of({ id: 9, title: 'A', completed: false, items: [] }));
+    component.handleTaskCreationAttempt();
+    expect(component.tasks[0].id).toBe(9);
+    component.newTaskName = '   ';
+    component.handleTaskCreationAttempt();
+    expect(taskServiceSpy.createTask.calls.count()).toBe(1);
+  });
+
+  it('handleTaskCreationAttempt: error path', fakeAsync(() => {
+    component.newTaskName = 'B';
+    taskServiceSpy.createTask.and.returnValue(throwError(() => new Error()));
+    component.handleTaskCreationAttempt();
+    tick();
+    expect(component.toastMessage).toBe('Error creating task');
+  }));
+
+  it('onTaskDeleted filters out the task', () => {
+    component.tasks = [...mockTasks];
+    component.onTaskDeleted(1);
+    expect(component.tasks.find(t => t.id === 1)).toBeUndefined();
+  });
+
 });

--- a/src/app/components/board/board.component.ts
+++ b/src/app/components/board/board.component.ts
@@ -64,7 +64,7 @@ export class BoardComponent implements OnInit {
         this.loading = false;
       },
       error: (err) => {
-        console.error('Error al cargar las tareas del board:', err);
+        this.showToast('Failed to load board data.', 'error');
         this.tasks = [];
         this.loading = false;
       }
@@ -83,10 +83,9 @@ export class BoardComponent implements OnInit {
         this.board.title = trimmedTitle;
         this.originalTitle = trimmedTitle;
         this.titleInputRef.nativeElement.blur();
-        console.log('Board title updated successfully:', this.board.title);
         },
         error: (err) => {
-          console.error('Error updating board title:', err);
+          this.showToast('Failed to update board.', 'error');
           this.boardTitle = this.originalTitle;
         }
       });
@@ -129,11 +128,10 @@ export class BoardComponent implements OnInit {
     this.openConfirm('Are you sure you want to delete this board?', () => {
       this.boardService.deleteBoard(this.board.id).subscribe({
         next: () => {
-          console.log('Board deleted successfully');
           this.boardService.notifyBoardDeleted();
         },
         error: (err) => {
-          console.error('Error deleting board:', err);
+          this.showToast('Failed to delete board.', 'error');
         }
       });
     });

--- a/src/app/components/board/board.component.ts
+++ b/src/app/components/board/board.component.ts
@@ -1,0 +1,158 @@
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef , HostListener, Input, OnInit, ViewChild } from '@angular/core';
+import { TaskComponent } from '../task/task.component';
+import { Board } from '../../models/board.model';
+import { Task } from '../../models/task.model';
+import { BoardService } from '../../services/board.service';
+import { TaskService } from '../../services/task.service';
+import { FormsModule } from '@angular/forms';
+import { DragScrollComponent } from 'ngx-drag-scroll';
+import { ToastComponent } from '../toast/toast.component';
+import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.component';
+
+
+@Component({
+  selector: 'app-board',
+  standalone: true,
+  imports: [CommonModule, TaskComponent, DragScrollComponent, FormsModule, ToastComponent, ConfirmDialogComponent],
+  templateUrl: './board.component.html',
+  styleUrls: ['./board.component.css'],
+})
+export class BoardComponent implements OnInit {
+  @Input() board!: Board;
+
+  @ViewChild('titleInputRef') titleInputRef!: ElementRef<HTMLInputElement>;
+
+  tasks: Task[] = [];
+  loading = true;
+
+  showDeleteButton = false;
+  private blurTimeout: any;
+
+  boardTitle: string = '';
+  originalTitle: string = '';
+
+  showConfirm = false;
+  confirmMessage = '';
+  confirmAction: () => void = () => {};
+
+  toastMessage = '';
+  toastType: 'success' | 'error' = 'success';
+
+  constructor(private taskService: TaskService, private boardService: BoardService) {}
+
+  ngOnInit(): void {
+    this.fetchTasks();
+    this.boardTitle = this.board.title;
+    this.originalTitle = this.boardTitle;
+  }
+
+  ngOnChanges(): void {
+    if (this.board) {
+      this.fetchTasks();
+      this.boardTitle = this.board.title;
+      this.originalTitle = this.boardTitle;
+    }
+  }
+
+  private fetchTasks(): void {
+    this.loading = true;
+
+    this.taskService.getTasksByBoard(this.board.id).subscribe({
+      next: (tasks) => {
+        this.tasks = tasks;
+        this.loading = false;
+      },
+      error: (err) => {
+        console.error('Error al cargar las tareas del board:', err);
+        this.tasks = [];
+        this.loading = false;
+      }
+    });
+  }
+
+  saveTitleIfChanged(): void {
+    const trimmedTitle = this.boardTitle.trim();
+    if (trimmedTitle && trimmedTitle !== this.originalTitle) {
+      const updateBoard: Board = {
+        title: trimmedTitle,
+        id: this.board.id,
+      };
+      this.boardService.updateBoard(this.board.id, updateBoard).subscribe({
+        next: () => {
+        this.board.title = trimmedTitle;
+        this.originalTitle = trimmedTitle;
+        this.titleInputRef.nativeElement.blur();
+        console.log('Board title updated successfully:', this.board.title);
+        },
+        error: (err) => {
+          console.error('Error updating board title:', err);
+          this.boardTitle = this.originalTitle;
+        }
+      });
+    } else {
+      this.boardTitle = this.originalTitle;
+    }
+  }
+
+  cancelEditing(): void {
+    this.boardTitle = this.originalTitle;
+  }
+
+  onFocusTitle() {
+    clearTimeout(this.blurTimeout);
+    this.showDeleteButton = true;
+  }
+
+  onBlurTitle() {
+    this.blurTimeout = setTimeout(() => {
+      this.showDeleteButton = false;
+    }, 200);
+  }
+
+  openConfirm(message: string, action: () => void) {
+    this.confirmMessage = message;
+    this.confirmAction = action;
+    this.showConfirm = true;
+  }
+
+  handleConfirm() {
+    this.showConfirm = false;
+    this.confirmAction();
+  }
+
+  handleCancel() {
+    this.showConfirm = false;
+  }
+
+  deleteBoard(): void {
+    this.openConfirm('Are you sure you want to delete this board?', () => {
+      this.boardService.deleteBoard(this.board.id).subscribe({
+        next: () => {
+          console.log('Board deleted successfully');
+          this.boardService.notifyBoardDeleted();
+        },
+        error: (err) => {
+          console.error('Error deleting board:', err);
+        }
+      });
+    });
+  }
+
+  showToast(message: string, type: 'success' | 'error' = 'success') {
+    this.toastMessage = message;
+    this.toastType = type;
+    setTimeout(() => this.toastMessage = '', 3000);
+  }
+
+  @HostListener('document:click', ['$event'])
+  onClickOutside(event: MouseEvent) {
+    if (
+      this.titleInputRef &&
+      !this.titleInputRef.nativeElement.contains(event.target as Node)
+    ) {
+      this.cancelEditing();
+    }
+  }
+}
+

--- a/src/app/components/layouts/main-layout.component.html
+++ b/src/app/components/layouts/main-layout.component.html
@@ -1,16 +1,18 @@
-<div class="min-h-screen flex bg-darkgrey text-marfilwhite">
+<div class="h-screen flex bg-darkgrey text-marfilwhite overflow-y-hidden ">
   <!-- Sidebar -->
   <app-sidebar (boardSelected)="setSelectedBoard($event)"
   (toggleUserPanel)="toggleUserPanel()" />
   <!-- Main content area -->
   
-  <div class="flex-1 p-6">
+  <div class="flex-1 p-6 overflow-x-auto max-w-full">
     <ng-container *ngIf="showUserPanel">
       <app-user-management /> 
     </ng-container>
 
     <ng-container *ngIf="selectedBoard && !showUserPanel">
-      <router-outlet />
+        <app-board
+        [board]="selectedBoard">
+        </app-board>
     </ng-container>
 
     <div *ngIf="!selectedBoard && !showUserPanel" class="text-center text-marfilwhite text-3xl mt-20">

--- a/src/app/components/layouts/main-layout.component.ts
+++ b/src/app/components/layouts/main-layout.component.ts
@@ -1,19 +1,31 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { SidebarComponent } from "../sidebar/sidebar.component";
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { Board } from "../../models/board.model";
 import { UserManagementComponent } from "../user-management/user-management.component";
+import { BoardComponent } from '../board/board.component';
+import { DragScrollComponent, DragScrollItemDirective} from 'ngx-drag-scroll';
+import { BoardService } from '../../services/board.service';
 
 @Component({
   selector: 'app-main-layout',
   templateUrl: './main-layout.component.html',
   standalone: true,
-  imports: [SidebarComponent, UserManagementComponent, RouterModule, CommonModule],
+  imports: [SidebarComponent, UserManagementComponent, BoardComponent, RouterModule, CommonModule, DragScrollComponent, DragScrollItemDirective],
 })
 export class MainLayoutComponent {
+
+  constructor(private boardService: BoardService) {}
+
   selectedBoard: Board | null = null;
   showUserPanel: boolean = false;
+
+  ngOnInit(): void {
+    this.boardService.boardDeleted$.subscribe(() => {
+      this.selectedBoard = null;
+    });
+  }
 
   setSelectedBoard(board: Board) {
     this.showUserPanel = false;
@@ -27,4 +39,5 @@ export class MainLayoutComponent {
   selectedBoardId(): number | null {
     return this.selectedBoard ? this.selectedBoard.id : null;
   }
+
 }

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -4,7 +4,7 @@
       'w-60': !isCollapsed,
       'w-12': isCollapsed
     }"
-    class="bg-darkgrey text-marfilwhite flex flex-col transition-width duration-300 ease-in-out relative"
+    class="bg-lightgrey text-marfilwhite flex flex-col transition-width duration-300 ease-in-out relative"
   >
 
     <!-- Collapsed menu icon -->
@@ -16,11 +16,11 @@
       </div>
     </div>
 
-    <!-- Header -->
     <div class="flex flex-col h-full transition-all"
       [ngClass]="{
         'opacity-100 delay-100 duration-300 ease-in-out': !isCollapsed,
-        'opacity-0 duration-0 pointer-events-none': isCollapsed}">
+        'max-h-0 opacity-0 duration-0 pointer-events-none': isCollapsed}">
+      <!-- Header -->
       <button #header
         class="flex items-center space-x-2 p-4  justify-between cursor-pointer hover:text-lightblue transition-colors duration-200"
         (click)="toggleUserPanel.emit()"

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -65,6 +65,9 @@ export class SidebarComponent implements OnInit {
   ngOnInit(): void {
     this.fetchUser();
     setTimeout(() => this.calculateAndFetchBoards(), 0);
+    this.boardService.boardDeleted$.subscribe(() => {
+      setTimeout(() => this.calculateAndFetchBoards(), 0);
+    });
   }
 
   getInitial(): string {

--- a/src/app/components/task/task.component.html
+++ b/src/app/components/task/task.component.html
@@ -1,0 +1,131 @@
+<div #taskContainer
+  class="border min-w-100 p-3 my-2 min-h-20
+          outline-none flex flex-col select-none bg-darkblue"
+  tabindex="0"
+  [ngClass]="getTaskClasses(task, isFocused)"
+  (focusin)="focusInContainer()"
+  (focusout)="focusOutContainer()"
+>
+  <!-- Task title input -->
+    <textarea
+    #titleInputTask
+    [(ngModel)]="taskTitle"
+    [ngClass]="{
+    'select-none':!isFocused,
+    }"
+    placeholder="{{ taskTitle }}"
+    rows="1"
+    class="resize-none px-4 py-2 text-marfilwhite text-lg font-bold text-center
+            focus:outline-none focus:text-lightblue w-full overflow-hidden"
+    (keydown.enter)="onEnter($event)"
+    (input)="autoGrow($event)"
+    (blur)="onBlurTitle()"
+    ></textarea>
+
+
+  
+
+  <!-- Input to add a new item -->
+  <input *ngIf="isFocused"
+    class="w-full px-4 py-2 text-lightblue bg-darkblue border border-y-lightblue border-x-darkblue focus:outline-none"
+    placeholder="Add item..."
+    [(ngModel)]="newItemTitle"
+    (keydown.enter)="createItem()"
+    />
+
+  <!-- List of task items -->
+    <ul class="list-none">
+    <li *ngFor="let item of getSortedItemsDesc(); let i = index; let last = last"
+        class="w-full px-4 py-2 text-lightblue bg-darkblue border-b border-lightblue border-x-darkblue focus:outline-none flex items-center justify-between gap-2"
+        [ngClass]="{
+          'mb-2': last && task.items.length !== 0 && isFocused,
+          'border-t': i === 0 && !isFocused
+        }">
+      
+      <div class="flex items-center gap-2 w-full">
+        <label class="relative w-5 h-5 flex-shrink-0">
+          <input
+            type="checkbox"
+            [checked]="item.itemChecked"
+            (change)="toggleItemCheck(item)"
+            (mousedown)="$event.preventDefault()"
+            class="peer absolute inset-0 opacity-0 cursor-pointer"
+          />
+          <div
+            class="w-full h-full bg-darkblue border border-lightblue rounded-none peer-checked:border-green-500
+                  flex items-center justify-center"
+          >
+            <svg *ngIf="item.itemChecked" fill="#05df72" viewBox="0 0 32 32" class="w-10 h-10" xmlns="http://www.w3.org/2000/svg">
+                <path d="M5 16.577l2.194-2.195 5.486 5.484L24.804 7.743 27 9.937l-14.32 14.32z"/>
+            </svg>
+          </div>
+        </label>
+        
+        <textarea
+          #titleInputItem
+          [(ngModel)]="editableTitles[item.id]"
+          (input)="autoGrow($event)"
+          (keydown.enter)="onEnterItem($event, item)"
+          (blur)="onBlurItem(item)"
+          rows="1"
+          class="resize-none w-full bg-transparent px-2 py-1 text-marfilwhite font-medium
+            focus:outline-none focus:text-lightblue overflow-hidden"
+        ></textarea>
+      </div>
+
+
+      <!-- Item delete button -->
+      <button *ngIf="isFocused" class="focus:outline-none flex items-center justify-center"
+              aria-label="Delete item"
+              (click)="deleteItem(item.id)"
+              >
+        <svg viewBox="0 0 32 32" fill="#fb2c36" version="1.1" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg">
+          <path d="M30 7.249h-5.598l-3.777-5.665c-0.137-0.202-0.366-0.334-0.625-0.334h-8c-0 0-0.001 0-0.001 0-0.259 0-0.487 0.131-0.621 0.331l-0.002 0.003-3.777 5.665h-5.599c-0.414 0-0.75 0.336-0.75 0.75s0.336 0.75 0.75 0.75v0h3.315l1.938 21.319c0.036 0.384 0.356 0.682 0.747 0.682 0 0 0 0 0.001 0h16c0 0 0.001 0 0.001 0 0.39 0 0.71-0.298 0.745-0.679l0-0.003 1.938-21.319h3.316c0.414 0 0.75-0.336 0.75-0.75s-0.336-0.75-0.75-0.75v0zM12.401 2.75h7.196l2.999 4.499h-13.195zM23.314 29.25h-14.63l-1.863-20.5 18.358-0.001zM11 11.25c-0.414 0-0.75 0.336-0.75 0.75v0 14c0 0.414 0.336 0.75 0.75 0.75s0.75-0.336 0.75-0.75v0-14c-0-0.414-0.336-0.75-0.75-0.75v0zM16 11.25c-0.414 0-0.75 0.336-0.75 0.75v0 14c0 0.414 0.336 0.75 0.75 0.75s0.75-0.336 0.75-0.75v0-14c-0-0.414-0.336-0.75-0.75-0.75v0zM21 11.25c-0.414 0-0.75 0.336-0.75 0.75v0 14c0 0.414 0.336 0.75 0.75 0.75s0.75-0.336 0.75-0.75v0-14c-0-0.414-0.336-0.75-0.75-0.75v0z"></path>
+        </svg>
+      </button>
+    </li>
+  </ul>
+
+
+  <!-- Action buttons (visible on focus) -->
+  <div *ngIf="isFocused" class="flex justify-between gap-2">
+    <button class="focus:outline-none flex items-center justify-center"
+            (click)="deleteTask()"
+            aria-label="Delete task">
+            <svg viewBox="0 0 32 32" fill="#fb2c36" version="1.1" class="w-6 h-6" xmlns="http://www.w3.org/2000/svg">
+                <path d="M30 7.249h-5.598l-3.777-5.665c-0.137-0.202-0.366-0.334-0.625-0.334h-8c-0 0-0.001 0-0.001 0-0.259 0-0.487 0.131-0.621 0.331l-0.002 0.003-3.777 5.665h-5.599c-0.414 0-0.75 0.336-0.75 0.75s0.336 0.75 0.75 0.75v0h3.315l1.938 21.319c0.036 0.384 0.356 0.682 0.747 0.682 0 0 0 0 0.001 0h16c0 0 0.001 0 0.001 0 0.39 0 0.71-0.298 0.745-0.679l0-0.003 1.938-21.319h3.316c0.414 0 0.75-0.336 0.75-0.75s-0.336-0.75-0.75-0.75v0zM12.401 2.75h7.196l2.999 4.499h-13.195zM23.314 29.25h-14.63l-1.863-20.5 18.358-0.001zM11 11.25c-0.414 0-0.75 0.336-0.75 0.75v0 14c0 0.414 0.336 0.75 0.75 0.75s0.75-0.336 0.75-0.75v0-14c-0-0.414-0.336-0.75-0.75-0.75v0zM16 11.25c-0.414 0-0.75 0.336-0.75 0.75v0 14c0 0.414 0.336 0.75 0.75 0.75s0.75-0.336 0.75-0.75v0-14c-0-0.414-0.336-0.75-0.75-0.75v0zM21 11.25c-0.414 0-0.75 0.336-0.75 0.75v0 14c0 0.414 0.336 0.75 0.75 0.75s0.75-0.336 0.75-0.75v0-14c-0-0.414-0.336-0.75-0.75-0.75v0z"></path>
+                </svg>
+        </button>
+        <button *ngIf="task.items.length==0"
+        class="focus:outline-none flex items-center justify-center w-9 h-9"
+        (click)="toggleCheckTask()"
+        aria-label="Complete task">
+
+            <!-- SVG si task.completed es false -->
+            <svg *ngIf="!task.completed" fill="#05df72" viewBox="0 0 32 32" class="w-10 h-10" xmlns="http://www.w3.org/2000/svg">
+                <path d="M5 16.577l2.194-2.195 5.486 5.484L24.804 7.743 27 9.937l-14.32 14.32z"/>
+            </svg>
+
+            <!-- SVG si task.completed es true -->
+            <svg *ngIf="task.completed" fill="#fb2c36" viewBox="0 0 16 16" class="w-5 h-5" xmlns="http://www.w3.org/2000/svg">
+                <path d="M0 14.545L1.455 16 8 9.455 14.545 16 16 14.545 9.455 8 16 1.455 14.545 0 8 6.545 1.455 0 0 1.455 6.545 8z" fill-rule="evenodd"/>
+            </svg>
+
+        </button>
+  </div>
+
+<!-- Confirm message component -->
+  <app-confirm-dialog
+        *ngIf="showConfirm"
+        [message]="confirmMessage"
+        (confirm)="handleConfirm()"
+        (cancel)="handleCancel()"
+    ></app-confirm-dialog>
+
+  <!-- Toast message component -->
+  <app-toast
+    *ngIf="toastMessage"
+    [message]="toastMessage"
+    [type]="toastType"
+  ></app-toast>
+</div>

--- a/src/app/components/task/task.component.spec.ts
+++ b/src/app/components/task/task.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TaskComponent } from './task.component';
+
+describe('TaskComponent', () => {
+  let component: TaskComponent;
+  let fixture: ComponentFixture<TaskComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TaskComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TaskComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/task/task.component.spec.ts
+++ b/src/app/components/task/task.component.spec.ts
@@ -1,23 +1,224 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { TaskComponent } from './task.component';
+import { TaskService } from '../../services/task.service';
+import { ItemService } from '../../services/item.service';
+import { of, throwError } from 'rxjs';
+import { Task } from '../../models/task.model';
+import { Item } from '../../models/item.model';
+import { ItemRequest } from '../../models/item-request.model';
+import { ElementRef, QueryList } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ToastComponent } from '../toast/toast.component';
+import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.component';
 
 describe('TaskComponent', () => {
   let component: TaskComponent;
   let fixture: ComponentFixture<TaskComponent>;
+  let taskServiceSpy: jasmine.SpyObj<TaskService>;
+  let itemServiceSpy: jasmine.SpyObj<ItemService>;
+
+  const mockItems: Item[] = [
+    { id: 1, title: 'Item 1', itemChecked: false },
+    { id: 2, title: 'Item 2', itemChecked: true }
+  ];
+  const initialTask: Task = { id: 10, title: 'T', completed: false, items: mockItems };
 
   beforeEach(async () => {
+    taskServiceSpy = jasmine.createSpyObj('TaskService', ['updateTask','deleteTask','toggleCheckTask']);
+    itemServiceSpy = jasmine.createSpyObj('ItemService', ['createItem','updateItem','toggleCheckItem','deleteItem']);
+
     await TestBed.configureTestingModule({
-      imports: [TaskComponent]
-    })
-    .compileComponents();
+      imports: [
+        TaskComponent,
+        FormsModule,
+        ToastComponent,
+        ConfirmDialogComponent
+      ],
+      providers: [
+        { provide: TaskService, useValue: taskServiceSpy },
+        { provide: ItemService, useValue: itemServiceSpy }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(TaskComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.taskContainer = new ElementRef(document.createElement('div'));
+    component.titleInputTask = new ElementRef(document.createElement('textarea'));
+    component.titleInputItems = new QueryList<ElementRef<HTMLTextAreaElement>>();
+    component.task = { ...initialTask };
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should create and init titles', () => {
+    component.ngOnInit();
+    expect(component.taskTitle).toBe('T');
+    expect(component.editableTitles[1]).toBe('Item 1');
   });
+
+  it('autoGrow adjusts height', () => {
+    const ta = document.createElement('textarea');
+    ta.style.height = '10px';
+    component.autoGrow({ target: ta } as any);
+    expect(ta.style.height).toBe('100px');
+  });
+
+  it('focusIn/outContainer toggles isFocused and autoGrow', fakeAsync(() => {
+    spyOn(component, 'autoGrow');
+    component.focusInContainer();
+    expect(component.isFocused).toBeTrue();
+    tick(10);
+    component.focusOutContainer();
+    expect(component.isFocused).toBeFalse();
+  }));
+
+  it('onEnter and onBlurTitle reset and grow', fakeAsync(() => {
+    spyOn(component, 'saveTitleIfChanged');
+    spyOn(component, 'autoGrow');
+    component.onEnter({ preventDefault: ()=>{} } as any);
+    expect(component.saveTitleIfChanged).toHaveBeenCalled();
+    tick(100);
+    component.onBlurTitle();
+    expect(component.taskTitle).toBe(component.originalTitle);
+  }));
+
+  describe('saveTitleIfChanged', () => {
+    beforeEach(()=>component.ngOnInit());
+    it('updates on change', () => {
+      component.taskTitle = 'X';
+      taskServiceSpy.updateTask.and.returnValue(of({ ...initialTask, title:'X' }));
+      spyOn(component.titleInputTask.nativeElement,'blur');
+      component.saveTitleIfChanged();
+      expect(component.task.title).toBe('X');
+    });
+    it('no-op on same/empty', () => {
+      component.taskTitle = '   ';
+      component.saveTitleIfChanged();
+      expect(taskServiceSpy.updateTask).not.toHaveBeenCalled();
+    });
+    it('error path', () => {
+      component.taskTitle = 'Y';
+      taskServiceSpy.updateTask.and.returnValue(throwError(()=>new Error()));
+      component.saveTitleIfChanged();
+      expect(component.toastType).toBe('error');
+    });
+  });
+
+  describe('deleteTask', () => {
+    beforeEach(()=>{
+      spyOn(component, 'openConfirm').and.callThrough();
+      component.taskDeleted = jasmine.createSpyObj('EventEmitter',['emit']);
+    });
+    it('emit on confirm', () => {
+      taskServiceSpy.deleteTask.and.returnValue(of(undefined));
+      component.deleteTask();
+      component.handleConfirm();
+      expect(component.taskDeleted.emit).toHaveBeenCalledWith(10);
+    });
+    it('error path', () => {
+      taskServiceSpy.deleteTask.and.returnValue(throwError(()=>new Error()));
+      component.deleteTask();
+      component.handleConfirm();
+      expect(component.toastType).toBe('error');
+    });
+  });
+
+  describe('toggleCheckTask', () => {
+    it('success', () => {
+      const upt = {...initialTask, completed:true};
+      taskServiceSpy.toggleCheckTask.and.returnValue(of(upt));
+      component.toggleCheckTask();
+      expect(component.task.completed).toBeTrue();
+    });
+    it('error', () => {
+      taskServiceSpy.toggleCheckTask.and.returnValue(throwError(()=>new Error()));
+      component.toggleCheckTask();
+      expect(component.toastType).toBe('error');
+    });
+  });
+
+  describe('createItem', () => {
+    beforeEach(()=>component.ngOnInit());
+    it('success', () => {
+      component.newItemTitle='Hello';
+      const nt = {...initialTask, items:[...mockItems,{id:3,title:'Hello',itemChecked:false}]};
+      itemServiceSpy.createItem.and.returnValue(of(nt));
+      component.createItem();
+      expect(component.task.items.length).toBe(3);
+    });
+    it('empty no call', ()=> {
+      component.newItemTitle='   ';
+      component.createItem();
+      expect(itemServiceSpy.createItem).not.toHaveBeenCalled();
+    });
+    it('error', fakeAsync(()=>{
+      component.newItemTitle='E';
+      itemServiceSpy.createItem.and.returnValue(throwError(()=>new Error()));
+      component.createItem();
+      tick();
+      expect(component.toastType).toBe('error');
+    }));
+  });
+
+  describe('saveItemTitleIfChanged', () => {
+    beforeEach(()=>component.ngOnInit());
+    it('success', fakeAsync(()=>{
+      const item=mockItems[0];
+      component.editableTitles[item.id]='New';
+      const ut={...initialTask,items:[{...item,title:'New'}]};
+      itemServiceSpy.updateItem.and.returnValue(of(ut));
+      component.saveItemTitleIfChanged(item);
+      tick();
+      expect(component.task.items[0].title).toBe('New');
+    }));
+    it('no change', ()=>{
+      const item=mockItems[0];
+      component.editableTitles[item.id]=item.title;
+      component.saveItemTitleIfChanged(item);
+      expect(itemServiceSpy.updateItem).not.toHaveBeenCalled();
+    });
+    it('error', fakeAsync(()=>{
+      const item=mockItems[0];
+      component.editableTitles[item.id]='Err';
+      itemServiceSpy.updateItem.and.returnValue(throwError(()=>new Error()));
+      component.saveItemTitleIfChanged(item);
+      tick();
+      expect(component.toastType).toBe('error');
+    }));
+  });
+
+  describe('toggleItemCheck', () => {
+    it('success', ()=>{
+      itemServiceSpy.toggleCheckItem.and.returnValue(of({...initialTask,items:[{...mockItems[0],itemChecked:true},mockItems[1]]}));
+      component.toggleItemCheck(mockItems[0]);
+      expect(component.task.items[0].itemChecked).toBeTrue();
+    });
+    it('error', ()=>{
+      itemServiceSpy.toggleCheckItem.and.returnValue(throwError(()=>new Error()));
+      component.toggleItemCheck(mockItems[0]);
+      expect(component.toastType).toBe('error');
+    });
+  });
+
+  describe('deleteItem', () => {
+    beforeEach(()=>spyOn(component,'openConfirm').and.callThrough());
+    it('success', ()=>{
+      const ut={...initialTask,items:[mockItems[1]]};
+      itemServiceSpy.deleteItem.and.returnValue(of(ut));
+      component.deleteItem(mockItems[0].id);
+      component.handleConfirm();
+      expect(component.task.items.length).toBe(1);
+    });
+    it('error', ()=>{
+      itemServiceSpy.deleteItem.and.returnValue(throwError(()=>new Error()));
+      component.deleteItem(mockItems[0].id);
+      component.handleConfirm();
+      expect(component.toastType).toBe('error');
+    });
+  });
+
+  it('getSortedItemsDesc orders desc', () => {
+    component.task.items = [{ id:5,title:'A',itemChecked:false },{ id:2,title:'B',itemChecked:false }];
+    const sorted = component.getSortedItemsDesc();
+    expect(sorted[0].id).toBe(5);
+  });
+
 });

--- a/src/app/components/task/task.component.ts
+++ b/src/app/components/task/task.component.ts
@@ -1,0 +1,270 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input , ViewChild, ElementRef, Output, EventEmitter, ViewChildren, QueryList  } from '@angular/core';
+import { Task } from '../../models/task.model';
+import { TaskService } from '../../services/task.service';
+import { ItemService } from '../../services/item.service';
+import { FormsModule } from '@angular/forms';
+import { ToastComponent } from '../toast/toast.component';
+import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.component';
+import { ItemRequest } from '../../models/item-request.model';
+import { Item } from '../../models/item.model';
+
+@Component({
+  selector: 'app-task',
+  standalone: true,
+  imports: [CommonModule , ToastComponent , ConfirmDialogComponent, FormsModule],
+  templateUrl: './task.component.html'
+})
+export class TaskComponent {
+  @Input() task!: Task;
+  @Output() taskDeleted = new EventEmitter<number>();
+
+  @ViewChild('taskContainer') taskContainer!: ElementRef;
+  @ViewChild('titleInputTask') titleInputTask!: ElementRef<HTMLTextAreaElement>;
+  @ViewChildren('titleInputItem') titleInputItems!: QueryList<ElementRef<HTMLTextAreaElement>>;
+
+
+  isFocused = false;
+
+  taskTitle: string = '';
+  originalTitle: string = '';
+
+  newItemTitle = '';
+
+  editableTitles: Record<number, string> = {};
+
+  toastMessage = '';
+  toastType: 'success' | 'error' = 'success';
+
+  showConfirm = false;
+  confirmMessage = '';
+  confirmAction: () => void = () => {};
+
+  constructor(private taskService: TaskService, private itemService: ItemService) {}
+
+  ngOnInit(): void {
+    this.taskTitle = this.task.title;
+    this.originalTitle = this.taskTitle;
+    this.task.items.forEach(item => {
+      this.editableTitles[item.id] = item.title;
+    });
+  }
+
+  ngAfterViewInit(): void {
+    if (this.titleInputTask && this.titleInputTask.nativeElement) {
+      this.autoGrow({ target: this.titleInputTask.nativeElement } as unknown as Event);
+    }
+
+    setTimeout(() => this.titleInputItems?.forEach(itemRef => {
+      this.autoGrow({ target: itemRef.nativeElement } as unknown as Event);
+    })
+    , 10);
+  }
+
+  focusInContainer(): void {
+    this.isFocused=true;
+
+    if (this.titleInputTask && this.titleInputTask.nativeElement) {
+      this.autoGrow({ target: this.titleInputTask.nativeElement } as unknown as Event);
+    }
+
+    setTimeout(() => this.titleInputItems?.forEach(itemRef => {
+      this.autoGrow({ target: itemRef.nativeElement } as unknown as Event);
+    })
+    , 10);
+  }
+
+  focusOutContainer(): void {
+    this.isFocused=false;
+
+    if (this.titleInputTask && this.titleInputTask.nativeElement) {
+      this.autoGrow({ target: this.titleInputTask.nativeElement } as unknown as Event);
+    }
+
+    setTimeout(() => this.titleInputItems?.forEach(itemRef => {
+      this.autoGrow({ target: itemRef.nativeElement } as unknown as Event);
+    })
+    , 10);
+  }
+
+  getTaskClasses(task: Task, isFocused: boolean): { [klass: string]: boolean } {
+    return {
+      'border-lightblue': !task.completed,
+      'border-green-400 border-2': task.completed,
+    };
+  }
+    
+  onEnter(event: Event): void {
+    (event as KeyboardEvent).preventDefault();
+    this.saveTitleIfChanged();
+    setTimeout(() => this.autoGrow({ target: this.titleInputTask.nativeElement } as unknown as Event), 100);
+  }
+
+  onBlurTitle() {
+    this.taskTitle = this.originalTitle;
+    setTimeout(() => this.autoGrow({ target: this.titleInputTask.nativeElement } as unknown as Event), 100);
+  }
+
+  autoGrow(event: Event): void {
+  const textarea = event.target as HTMLTextAreaElement;
+  textarea.style.height = 'auto';
+  textarea.style.height = `${textarea.scrollHeight}px`;
+  }
+
+  saveTitleIfChanged(): void {
+    const trimmedTitle = this.taskTitle.trim();
+    if (trimmedTitle && trimmedTitle !== this.originalTitle) {
+      const updateTask: Task = {
+        title: trimmedTitle,
+        id: this.task.id,
+        completed: this.task.completed,
+        items: this.task.items
+      };
+      this.taskService.updateTask(this.task.id, updateTask).subscribe({
+        next: () => {
+        this.task.title = trimmedTitle;
+        this.originalTitle = trimmedTitle;
+        this.titleInputTask.nativeElement.blur();
+        },
+        error: () => {
+          this.showToast('Failed to update task.', 'error');
+          this.taskTitle = this.originalTitle;
+        }
+      });
+    } else {
+      this.taskTitle = this.originalTitle;
+    }
+  }
+
+  deleteTask(): void {
+    this.openConfirm('Are you sure you want to delete this task?', () => {
+      this.taskService.deleteTask(this.task.id).subscribe({
+        next: () => {
+          this.taskDeleted.emit(this.task.id);
+        },
+        error: () => {
+          this.showToast('Failed to delete task.', 'error');
+        }
+      });
+    });
+  }
+
+  toggleCheckTask(): void {
+      this.taskService.toggleCheckTask(this.task.id).subscribe({
+        next: updated => {
+          this.task=updated
+        },
+        error: () => {
+          this.showToast('Failed to complete task.', 'error');
+        }
+      });
+  }
+
+  createItem() {
+    const newItemtitleTrimmed = this.newItemTitle.trim();
+    if (!newItemtitleTrimmed) return;
+    const createItemRequest: ItemRequest = {
+      title:newItemtitleTrimmed,
+    }
+    this.itemService.createItem(this.task.id, createItemRequest).subscribe({
+      next: createdItem => {
+          this.task=createdItem
+          const newItem = this.task.items[this.task.items.length - 1];
+          this.editableTitles[newItem.id] = newItem.title;
+          this.newItemTitle = '';
+        },
+      error: () => {
+        this.showToast('Error adding item.', 'error');
+      }
+    });
+  }
+
+  onEnterItem(event: Event, item: Item): void {
+    (event as KeyboardEvent).preventDefault();
+    this.saveItemTitleIfChanged(item);
+    this.focusOutContainer();
+  }
+
+  onBlurItem(item: Item) {
+    this.editableTitles[item.id] = item.title;
+  }
+
+  saveItemTitleIfChanged(item: Item): void {
+    const trimmedTitle = this.editableTitles[item.id].trim();
+    const original = item.title.trim();
+
+    if (trimmedTitle && trimmedTitle !== original) {
+      const updatedItem: ItemRequest = {
+        title: trimmedTitle
+      };
+      this.itemService.updateItem(item.id, updatedItem).subscribe({
+        next: updatedTask => {
+            this.task = updatedTask;
+            setTimeout(() => this.editableTitles[item.id] = trimmedTitle, 10);
+        },
+        error: () => {
+          this.showToast('Failed to update item title.', 'error');
+          this.editableTitles[item.id] = item.title;
+        }
+      });
+    } else {
+      this.editableTitles[item.id] = item.title;
+    }
+  }
+
+   toggleItemCheck(item: Item): void {
+      this.itemService.toggleCheckItem(item.id).subscribe({
+        next: updated => {
+          this.task=updated
+        },
+        error: () => {
+          this.showToast('Failed to complete item.', 'error');
+        }
+      });
+  }
+
+  deleteItem(itemId:number): void {
+    this.openConfirm('Are you sure you want to delete this item?', () => {
+      this.itemService.deleteItem(itemId).subscribe({
+        next: updatedTaskWithDeletedItem => {
+          this.task=updatedTaskWithDeletedItem
+          setTimeout(() => {
+            this.taskContainer?.nativeElement?.focus();
+          });
+        },
+        error: () => {
+          this.showToast('Failed to delete item.', 'error');
+        }
+      });
+    });
+  }
+
+  getSortedItemsDesc() {
+    return [...this.task.items].sort((a, b) => b.id - a.id);
+  }
+
+
+  openConfirm(message: string, action: () => void) {
+    this.confirmMessage = message;
+    this.confirmAction = action;
+    this.showConfirm = true;
+  }
+
+  handleConfirm() {
+    this.showConfirm = false;
+    this.confirmAction();
+  }
+
+  handleCancel() {
+    this.showConfirm = false;
+  }
+
+  showToast(message: string, type: 'success' | 'error' = 'success') {
+    this.toastMessage = message;
+    this.toastType = type;
+    setTimeout(() => this.toastMessage = '', 3000);
+  }
+
+
+}
+

--- a/src/app/constants/api-endpoints.ts
+++ b/src/app/constants/api-endpoints.ts
@@ -10,12 +10,16 @@ export const API_ENDPOINTS = {
   boards: {
     getAll: `${API_BASE_URL}/board/me`,
     create: `${API_BASE_URL}/board`,
-    getById: (id: string) => `${API_BASE_URL}/board/${id}`,
+    update: (boardId: number) => `${API_BASE_URL}/board/${boardId}`,
+    delete: (boardId: number) => `${API_BASE_URL}/board/${boardId}`,
   },
   users: {
     getCurrent: `${API_BASE_URL}/user/me`,
     update: `${API_BASE_URL}/user/me`,
     updatePassword: `${API_BASE_URL}/user/me/password`,
     delete: `${API_BASE_URL}/user/me`
+  },
+  tasks: {
+    getByBoard: (boardId: number) => `${API_BASE_URL}/task/${boardId}`,
   },
 };

--- a/src/app/constants/api-endpoints.ts
+++ b/src/app/constants/api-endpoints.ts
@@ -21,5 +21,15 @@ export const API_ENDPOINTS = {
   },
   tasks: {
     getByBoard: (boardId: number) => `${API_BASE_URL}/task/${boardId}`,
+    create: (boardId: number) => `${API_BASE_URL}/task/${boardId}`,
+    update: (taskId: number) => `${API_BASE_URL}/task/${taskId}`,
+    toggleCheck: (taskId: number) => `${API_BASE_URL}/task/toggle/${taskId}`,
+    delete: (taskId: number) => `${API_BASE_URL}/task/${taskId}`
   },
+  items: {
+    create: (taskId: number) => `${API_BASE_URL}/item/${taskId}`,
+    update: (itemId: number) => `${API_BASE_URL}/item/${itemId}`,
+    toggleCheck: (itemId: number) => `${API_BASE_URL}/item/toggle/${itemId}`,
+    delete: (itemId: number) => `${API_BASE_URL}/item/${itemId}`
+  }
 };

--- a/src/app/models/item-request.model.ts
+++ b/src/app/models/item-request.model.ts
@@ -1,0 +1,3 @@
+export interface ItemRequest {
+  title: string;
+}

--- a/src/app/models/item.model.ts
+++ b/src/app/models/item.model.ts
@@ -1,0 +1,5 @@
+export interface Item {
+  id: number;
+  title: string;
+  itemChecked: boolean;
+}

--- a/src/app/models/task.model.ts
+++ b/src/app/models/task.model.ts
@@ -1,0 +1,8 @@
+import { Item } from './item.model';
+
+export interface Task {
+  id: number;
+  title: string;
+  completed: boolean;
+  items: Item[];
+}

--- a/src/app/services/board.service.ts
+++ b/src/app/services/board.service.ts
@@ -1,7 +1,7 @@
 // src/app/services/board.service.ts
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { Board } from '../models/board.model';
 import { API_ENDPOINTS } from '../constants/api-endpoints';
 
@@ -12,17 +12,27 @@ export class BoardService {
 
   constructor(private http: HttpClient) {}
 
+  private boardDeletedSource = new Subject<void>();
+  boardDeleted$ = this.boardDeletedSource.asObservable();
+
+  notifyBoardDeleted() {
+    this.boardDeletedSource.next();
+  }
+
   getBoards(page: number, size: number): Observable<{ content: Board[]; totalPages: number }> {
     const params = new HttpParams().set('page', page.toString()).set('size', size.toString());
     return this.http.get<{ content: Board[]; totalPages: number }>(API_ENDPOINTS.boards.getAll, { params });
   }
 
-
   createBoard(board: Partial<Board>): Observable<Board> {
     return this.http.post<Board>(API_ENDPOINTS.boards.create, board);
   }
 
-  getBoardById(id: string): Observable<Board> {
-    return this.http.get<Board>(API_ENDPOINTS.boards.getById(id));
+  updateBoard(boardId: number, board: Partial<Board>): Observable<Board> {
+    return this.http.patch<Board>(API_ENDPOINTS.boards.update(boardId), board);
+  }
+
+  deleteBoard(boardId: number): Observable<void> {
+    return this.http.delete<void>(API_ENDPOINTS.boards.delete(boardId));
   }
 }

--- a/src/app/services/item.service.ts
+++ b/src/app/services/item.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Task } from '../models/task.model';
+import { API_ENDPOINTS } from '../constants/api-endpoints';
+import { ItemRequest } from '../models/item-request.model';
+
+@Injectable({ providedIn: 'root' })
+export class ItemService {
+  constructor(private http: HttpClient) {}
+
+  createItem(taskId: number, item: ItemRequest): Observable<Task> {
+    return this.http.post<Task>(API_ENDPOINTS.items.create(taskId), item);
+  }
+
+ updateItem(itemId: number, item: ItemRequest): Observable<Task> {
+    return this.http.patch<Task>(API_ENDPOINTS.items.update(itemId), item);
+  }
+
+  toggleCheckItem(itemId: number): Observable<Task> {
+    return this.http.patch<Task>(API_ENDPOINTS.items.toggleCheck(itemId),null);
+  }
+
+  deleteItem(itemId: number): Observable<Task> {
+    return this.http.delete<Task>(API_ENDPOINTS.items.delete(itemId));
+  }
+}

--- a/src/app/services/task.service.ts
+++ b/src/app/services/task.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Task } from '../models/task.model';
+import { API_ENDPOINTS } from '../constants/api-endpoints';
+
+@Injectable({ providedIn: 'root' })
+export class TaskService {
+  constructor(private http: HttpClient) {}
+
+  getTasksByBoard(boardId: number): Observable<Task[]> {
+    return this.http.get<Task[]>(API_ENDPOINTS.tasks.getByBoard(boardId));
+  }
+
+  createTask(boardId: number, task: Partial<Task>): Observable<Task> {
+    return this.http.post<Task>(API_ENDPOINTS.tasks.create(boardId), task);
+  }
+
+  updateTask(taskId: number, task: Partial<Task>): Observable<Task> {
+    return this.http.patch<Task>(API_ENDPOINTS.tasks.update(taskId), task);
+  }
+
+  toggleCheckTask(taskId: number): Observable<Task> {
+    return this.http.patch<Task>(API_ENDPOINTS.tasks.toggleCheck(taskId), null);
+  }
+  deleteTask(taskId: number): Observable<void> {
+    return this.http.delete<void>(API_ENDPOINTS.tasks.delete(taskId));
+  }
+}


### PR DESCRIPTION
Add board page, that includes Task and Items handling, with the following functionalities:

- Board:
   - Edit board title
   - Delete board

-  Task
   - Create new task in board
   - Edit task title
   - Mark as completed (toggle)
   - Delete task

-   Item
    - Create new item in task
    - Edit item title
    - Mark as completed (toggle)
    - Delete item