### PR TITLE
fix: update SidebarComponent user fetch test and TaskComponent autoGrow height test

### DIFF
--- a/src/app/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/components/sidebar/sidebar.component.spec.ts
@@ -21,6 +21,7 @@ describe('SidebarComponent', () => {
     userServiceSpy = jasmine.createSpyObj('UserService', ['getUser']);
 
     await TestBed.configureTestingModule({
+      imports: [SidebarComponent],
       providers: [
         { provide: BoardService, useValue: spy },
         { provide: UserService, useValue: userServiceSpy }
@@ -162,6 +163,7 @@ describe('SidebarComponent', () => {
   it('should fetch user on init', () => {
     userServiceSpy.getUser.and.returnValue(of({ firstName: 'Jane', lastName: 'Doe', email: 'jane@example.com', name: 'Jane' }));
     boardServiceSpy.getBoards.and.returnValue(of({ content: mockBoards, totalPages: 1 }));
+    boardServiceSpy.boardDeleted$ = of();
 
     component.ngOnInit();
 

--- a/src/app/components/task/task.component.spec.ts
+++ b/src/app/components/task/task.component.spec.ts
@@ -56,6 +56,8 @@ describe('TaskComponent', () => {
 
   it('autoGrow adjusts height', () => {
     const ta = document.createElement('textarea');
+    ta.value = 'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10';
+    Object.defineProperty(ta, 'scrollHeight', { value: 100, configurable: true });
     ta.style.height = '10px';
     component.autoGrow({ target: ta } as any);
     expect(ta.style.height).toBe('100px');

--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -1,1 +1,4 @@
-
+export const environment = {
+  production: false,
+  apiUrl: 'https://localhost:3000/api/v1',
+};


### PR DESCRIPTION
- SidebarComponent:

The test should fetch user on init was failing due to a missing mock implementation for the boardDeleted$ observable on the injected BoardService.
Added a stub for boardDeleted$ to the spy object so that ngOnInit can subscribe without errors, fixing the test without changing the component code.

- TaskComponent:

The autoGrow adjusts height test failed because the textarea element's scrollHeight was zero in the test environment, resulting in an incorrect height style.
The test now mocks scrollHeight to a fixed value (100) to ensure the height adjustment works as expected in tests.